### PR TITLE
Fix Plugin for redmine 3.x

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -342,9 +342,9 @@ class GraphsController < ApplicationController
         if !@project.nil?
             ids = [@project.id]
             ids += @project.descendants.active.visible.collect(&:id)
-            @issues = Issue.visible.includes(:status).where("#{IssueStatus.table_name}.is_closed=? AND #{Project.table_name}.id IN (?)", false, ids)
+            @issues = Issue.visible.joins(:status).where("#{IssueStatus.table_name}.is_closed = ? AND #{Project.table_name}.id IN (?)", false, ids)
         else
-            @issues = Issue.visible.includes(:status).where("#{IssueStatus.table_name}.is_closed=?", false)
+            @issues = Issue.visible.joins(:status).where("#{IssueStatus.table_name}.is_closed = ?", false)
         end
     rescue ActiveRecord::RecordNotFound
         render_404
@@ -355,9 +355,9 @@ class GraphsController < ApplicationController
         if !@project.nil?
             ids = [@project.id]
             ids += @project.descendants.active.visible.collect(&:id)
-            @bugs = Issue.visible.includes(:status).where("#{Issue.table_name}.tracker_id IN (?) AND #{Project.table_name}.id IN (?)", 1, ids).to_a
+            @bugs = Issue.visible.joins(:status).where("#{Issue.table_name}.tracker_id IN (?) AND #{Project.table_name}.id IN (?)", 1, ids).to_a
         else
-            @bugs = Issue.visible.includes(:status).where("#{Issue.table_name}.tracker_id IN (?)", 1).to_a
+            @bugs = Issue.visible.joins(:status).where("#{Issue.table_name}.tracker_id IN (?)", 1).to_a
         end
     rescue ActiveRecord::RecordNotFound
         render_404


### PR DESCRIPTION
Without this patch we see this in the production.log:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'issue_statuses.is_closed' in 'where clause': SELECT `issues`.* FROM `issues` INNER JOIN `projects` ON `projects`.`id` = `issues`.`project_id` WHERE (((projects.status <> 9 AND projects.id IN 
                (SELECT em.project_id FROM enabled_modules em WHERE em.name='issue_tracking')) AND ((projects.is_public = 1 AND ((issues.is_private = 0)))))) AND (issue_statuses.is_closed=0 AND projects.id IN (56))
```

```
$ rails -v
Rails 4.2.1
$ ruby -v
ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
```

Redmine is 3.0.2